### PR TITLE
Add support to use ip of the host computer

### DIFF
--- a/src/ipdata.spec.ts
+++ b/src/ipdata.spec.ts
@@ -2,18 +2,9 @@ import { lookup } from './ipdata';
 import { expect } from 'chai';
 
 describe('lookup()', () => {
-  it('should throw an error if ip is undefined', async () => {
+  it('should throw an error for an empty string', async () => {
     try {
-      await lookup(undefined);
-    } catch (e) {
-      expect(e).to.be.instanceof(Error);
-      expect(e.message).to.equal('Please provide a valid ip.');
-    }
-  });
-
-  it('should throw an error if ip is null', async () => {
-    try {
-      await lookup(null);
+      await lookup('');
     } catch (e) {
       expect(e).to.be.instanceof(Error);
       expect(e.message).to.equal('Please provide a valid ip.');
@@ -27,6 +18,25 @@ describe('lookup()', () => {
       expect(e).to.be.instanceof(Error);
       expect(e.message).to.equal('Please provide a valid ip.');
     }
+  });
+
+  it('should throw an error for a private ip', async () => {
+    try {
+      await lookup('203.0.113.0');
+      throw new Error('This test should fail.');
+    } catch (e) {
+      expect(e.message).to.equal('400 - "203.0.113.0 is a private IP address"');
+    }
+  });
+
+  it('should return information when the ip is undefined', async () => {
+    const result = await lookup(undefined);
+    expect(result).to.not.be.undefined;
+  });
+
+  it('should return information when the ip is null', async () => {
+    const result = await lookup(null);
+    expect(result).to.not.be.undefined;
   });
 
   it('should return information for a valid ip', async () => {
@@ -50,14 +60,5 @@ describe('lookup()', () => {
       region: '',
       time_zone: ''
     });
-  });
-
-  it('should throw an error for a private ip', async () => {
-    try {
-      await lookup('203.0.113.0');
-      throw new Error('This test should fail.');
-    } catch (e) {
-      expect(e.message).to.equal('400 - "203.0.113.0 is a private IP address"');
-    }
   });
 });

--- a/src/ipdata.ts
+++ b/src/ipdata.ts
@@ -20,16 +20,16 @@ export interface IPDataLookupResponse {
   time_zone: string
 }
 
-export async function lookup(ip: string): Promise<IPDataLookupResponse> {
+export async function lookup(ip?: string, apiKey?: string): Promise<IPDataLookupResponse> {
   // Regex found on https://www.regular-expressions.info/ip.html
   const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
-  if (!ipRegex.test(ip)) {
+  if (ip != null && !ipRegex.test(ip)) {
     return Promise.reject(new Error('Please provide a valid ip.'));
   }
 
   return await request({
-    uri: `https://api.ipdata.co/${ip}`,
+    uri: `https://api.ipdata.co/${ip ? ip : ''}`,
     json: true
   });
 }


### PR DESCRIPTION
You can do `lookup()` with no arguments to lookup information for the ip of the host computer.