### PR TITLE
Add named export for ESM compatibility

### DIFF
--- a/src/ipdata.ts
+++ b/src/ipdata.ts
@@ -135,7 +135,7 @@ export interface LookupResponse {
   status: number;
 }
 
-export default class IPData {
+export class IPData {
   apiKey: string;
   baseUrl: string;
   cache: LRUCache<string, LookupResponse>;
@@ -255,3 +255,5 @@ export default class IPData {
     return responses;
   }
 }
+
+export default IPData;


### PR DESCRIPTION
Fixes #41 — `import { IPData } from 'ipdata'` now works alongside the existing default export and `require('ipdata')`.

https://claude.ai/code/session_01UabaLo3R3sXovyxaZo2yCF