### PR TITLE
Fix broken release workflow and modernize CI configuration

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -22,9 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -22,9 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Test
@@ -33,19 +37,22 @@ jobs:
   release:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build
       - name: Release
-        run: npm publish
+        run: npm publish --provenance --access public
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "JavaScript library to gather information for an ip using https://ipdata.co.",
   "main": "./lib/ipdata.js",
+  "types": "./lib/ipdata.d.ts",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
- Update actions/checkout and actions/setup-node from v3 to v4
- Pin node-version to 22 across all workflow jobs
- Add types field to package.json for TypeScript declarations
- Add --provenance and --access public flags to npm publish
- Add permissions for provenance attestation in release job
- Remove unused GITHUB_TOKEN env var from release step

https://claude.ai/code/session_013nXRP16SMzhjtXMtFkXb57